### PR TITLE
Replace results with experiment/results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 ## General
-results/*
+experiment/results/*
 models/exp_models/*
 models/*/*
 tools/*.sh

--- a/tools/train.py
+++ b/tools/train.py
@@ -106,7 +106,7 @@ if __name__ == '__main__':
         else:
             print "=> no checkpoint found at '{}'".format(args.resume)    
     
-    res_file = '../results/%s.txt'%args.name
+    res_file = '../experiment/results/%s.txt'%args.name
     if not osp.exists('../experiment/results'):
         os.makedirs('../experiment/results')
     save_dir = '../models/%s'%args.name


### PR DESCRIPTION
It appears that the path in [Line 109 of train.py](https://github.com/GriffinLiang/vrd-dsr/blob/master/tools/train.py#L109) should be `../experiment/results/`, because the code immediately following it checks and creates that directory.

Currently, if the `results` directory is not present in the project root, [this](https://github.com/GriffinLiang/vrd-dsr/blob/master/tools/train.py#L121) fails.